### PR TITLE
initial update for Kong 1.x compatibility

### DIFF
--- a/kong-plugin-perimeterx-2.0.1-1.rockspec
+++ b/kong-plugin-perimeterx-2.0.1-1.rockspec
@@ -15,14 +15,13 @@ description = {
 }
 
 dependencies = {
-    "perimeterx-nginx-plugin == 6.0"
+    "perimeterx-nginx-plugin == 6.2.1"
 }
 
-local pluginName = "perimeterx"
 build = {
   type = "builtin",
   modules = {
-    ["kong.plugins."..pluginName..".handler"] = "kong/plugins/"..pluginName.."/handler.lua",
-    ["kong.plugins."..pluginName..".schema"] = "kong/plugins/"..pluginName.."/schema.lua",
+    ["kong.plugins.perimeterx.handler"] = "kong/plugins/perimeterx/handler.lua",
+    ["kong.plugins.perimeterx.schema"] = "kong/plugins/perimeterx/schema.lua",
   }
 }

--- a/kong/plugins/perimeterx/schema.lua
+++ b/kong/plugins/perimeterx/schema.lua
@@ -1,4 +1,3 @@
-local Errors = require "kong.dao.errors"
 
 return {
     no_consumer = true, -- this plugin will only be API-wide,
@@ -40,8 +39,25 @@ return {
         whitelist_ua_full = {type = "array", default = {}},
         whitelist_ua_sub = {type = "array", default = {}}
     },
+    entity_checks = {
+        { conditional = {
+            if_field = "api_protection_mode",
+            if_match = { eq = true, },
+            then_field = "api_protection_block_url",
+            then_match = { required = true },
+        }, },
+        { conditional = {
+            if_field = "api_protection_mode",
+            if_match = { eq = true, },
+            then_field = "api_protection_default_redirect_url",
+            then_match = { required = true },
+        }, },
+    },
+    -- TODO: deprecated, `self_check` is the Kong 0.x mechanism for custom
+    -- validations, which was replaced by the above `entity_checks` in Kong 1.x
     self_check = function(schema, plugin_t, dao, is_updating)
         -- perform any custom verification
+        local Errors = require "kong.dao.errors"
         local config = plugin_t
 
         if config.api_protection_mode then


### PR DESCRIPTION
Note1: untested. Updated the code to the point where Kong would start with the plugin enabled.

Note2: builds on top of https://github.com/PerimeterX/perimeterx-kong-plugin/pull/18